### PR TITLE
Adding OpenSauced Social Icon and Profile Link

### DIFF
--- a/src/assets/socialIcons.ts
+++ b/src/assets/socialIcons.ts
@@ -214,6 +214,14 @@ const socialIcons: SocialIcons = {
       35.742C26.303,37.858 28.9,41.873 28.997,47.662L29,48ZM40.814,7.186C42.376,8.748 43.009,10.648 42.228,11.428C41.447,12.209 39.548,11.576 37.986,10.014C36.424,8.452 35.791,6.552 36.572,5.772C37.353,4.991 39.252,5.624 40.814,7.186Z" style="fill:none;stroke-width:4.8px;"/>
     </g>
   </svg>`,
+  OpenSauced: `<svg class="icon-tabler" version="1.0" xmlns="http://www.w3.org/2000/svg"
+  width="32.000000pt" height="32.000000pt" viewBox="0 0 32.000000 32.000000"
+  preserveAspectRatio="xMidYMid meet">
+    <g transform="translate(0.000000,32.000000) scale(0.100000,-0.100000)"
+    fill="currentColor" stroke="none">
+      <path d="M142 253 c-25 -37 -81 -165 -84 -195 -3 -23 -2 -23 91 -21 52 2 99 7 103 11 5 5 6 51 2 102 -5 71 -12 98 -26 112 -27 27 -63 23 -86 -9z"/>
+    </g>
+  </svg>`,
 };
 
 export default socialIcons;

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export const SITE: Site = {
   title: "aatmmr.dev",
   ogImage: "aatmmr-og.jpg",
   lightAndDarkMode: true,
-  postPerPage:5,
+  postPerPage: 5,
 };
 
 export const LOCALE = ["en-EN"]; // set to [] to use the environment default
@@ -42,6 +42,12 @@ export const SOCIALS: SocialObjects = [
     name: "Sessionize",
     href: "https://sessionize.com/maik-mueller/",
     linkTitle: `${SITE.title} on Sessionize`,
+    active: true,
+  },
+  {
+    name: "OpenSauced",
+    href: "https://app.opensauced.pizza/user/aatmmr?tab=contributions",
+    linkTitle: `${SITE.title} on OpenSauced`,
     active: true,
   },
 ];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,7 +49,7 @@ const socialCount = SOCIALS.filter(social => social.active).length;
         // only display if at least one social link is enabled
         socialCount > 0 && (
           <div class="social-wrapper">
-            <div class="social-links">Social Links:</div>
+            <div class="social-links">Socials:</div>
             <Socials />
           </div>
         )

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,4 +40,5 @@ export type SocialMedia =
   | "Steam"
   | "Telegram"
   | "Mastodon"
-  | "Sessionize";
+  | "Sessionize"
+  | "OpenSauced";


### PR DESCRIPTION
This pull request adds a new social link for "OpenSauced" and makes related updates to the codebase. The most important changes include adding "OpenSauced" as a valid option in the `SocialMedia` type, updating the text displayed above the social links, and adding the SVG icon for "OpenSauced" to the UI.

Main interface changes:

* <a href="diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL43-R44">`src/types.ts`</a>: Added "OpenSauced" as a valid option in the `SocialMedia` type.
* <a href="diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L52-R52">`src/pages/index.astro`</a>: Updated the text displayed above the social links from "Social Links" to "Socials".
* <a href="diffhunk://#diff-fe79ed0b7ffb6dbec39a5a08664209b1b88c4da81ff463808fad733aa85e5f60R217-R224">`src/assets/socialIcons.ts`</a>: Added the SVG icon for "OpenSauced" to the `socialIcons` object.

Configuration changes:

* <a href="diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R47-R52">`src/config.ts`</a>: Added a new social link for "OpenSauced" in the `SOCIALS` array.