### PR TITLE
content(about): changing to Solidify

### DIFF
--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -3,7 +3,7 @@ layout: ../layouts/AboutLayout.astro
 title: "About"
 ---
 
-My name is Maik, and I am a DevOps Consultant, GitHub Trainer, and GitHub Flight Instructor at <a href="https://xebia.com/digital-transformation/microsoft-services/">Xebia | Microsoft Services</a>. I spend most of my day with GitHub, deep-diving into any corner of the platform and becoming an Octowizard, and I like to share my knowledge and findings.
+My name is Maik, and I am a Senior Solution Architect, GitHub Trainer, and Octowizard at <a href="https://solidify.dev/">Solidify</a>. I spend most of my day with GitHub, deep-diving into any corner of the platform and becoming an Octowizard, and I like to share my knowledge and findings.
 
 ## Badges
 


### PR DESCRIPTION
This pull request includes a small change to the `src/pages/about.md` file. The change updates the job title and company information in the "About" section.

* [`src/pages/about.md`](diffhunk://#diff-e91269a1f665a0183ba546be6a40fee73a319f0a3cffe380e52c22030a2c6f75L6-R6): Updated job title from "DevOps Consultant" to "Senior Solution Architect" and changed the company from "Xebia | Microsoft Services" to "Solidify".